### PR TITLE
Correctly match border widths with more precision

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -434,7 +434,7 @@ export default function(elems, options = {}) {
             ['Width'].forEach((property) => {
               let borderWidth = cellStyles[`border${side}${property}`];
               if (isFirefox) {
-                const value = borderWidth.match(/(\d\.?\d?)([a-z%]+)/);
+                const value = borderWidth.match(/(\d\.?\d+)([a-z%]+)/);
                 borderWidth = `${Math.round(value[1])}${value[2]}`;
               }
               cell.style[`margin${side}`] = `-${borderWidth}`;


### PR DESCRIPTION
Right now if the border width is something like `1.11667px`, the match will be `[ "67px", "67", "px" ]` instead of `[ "1.11667px", "1.11667", "px" ]`. Changing the `?` to a `+` fixes that.