### PR TITLE
Fix Safari scroll issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,60 +52,6 @@ function updateScrollPosition(table, wrapper, callback) {
   }
 }
 
-function buildInnerCell(cell) {
-  const cellStyles = window.getComputedStyle(cell);
-  cell.classList.add("sns__placeholder-cell");
-  let innerCell = document.createElement("div");
-  innerCell.setAttribute("class", "sns__cell-inner");
-  let cellContents = document.createElement("div");
-  cellContents.setAttribute("class", "sns__cell-contents");
-  let setStyles = true;
-  while (cell.firstChild) {
-    cellContents.appendChild(cell.firstChild);
-    if (
-      cell.firstChild &&
-      cell.firstChild.classList &&
-      cell.firstChild.classList.contains("sns__cell-inner")
-    ) {
-      while (cell.firstChild.firstChild.firstChild) {
-        cellContents.appendChild(cell.firstChild.firstChild.firstChild);
-      }
-      innerCell.setAttribute("style", cell.firstChild.getAttribute("style"));
-      innerCell.style.height = "";
-      cell.firstChild.remove();
-      setStyles = false;
-    }
-  }
-  innerCell.appendChild(cellContents);
-  cell.innerHTML = "";
-  cell.appendChild(innerCell);
-
-  if (setStyles) {
-    ["padding", "border"].forEach((property) => {
-      ["Top", "Right", "Bottom", "Left"].forEach((side) => {
-        if (property === "border") {
-          const borderWidth = cellStyles[`border${side}Width`];
-          innerCell.style[
-            `margin${altSide(side)}`
-          ] = `calc(-1 * ${borderWidth})`;
-
-          ["Width", "Color", "Style"].forEach((attr) => {
-            const value = cellStyles[`${property}${side}${attr}`];
-            innerCell.style[`${property}${side}${attr}`] = value;
-          });
-        } else {
-          innerCell.style[`${property}${side}`] =
-            cellStyles[`${property}${side}`];
-        }
-      });
-      cell.style[property] = "0";
-    });
-
-    innerCell.style.display = "flex";
-    innerCell.style.alignItems = verticalAlignment(cellStyles.verticalAlign);
-  }
-}
-
 // Convert regular `vertical-align` CSS into flexbox friendly alternative.
 function verticalAlignment(value) {
   switch (value) {

--- a/index.js
+++ b/index.js
@@ -16,49 +16,6 @@ function altSide(side) {
   }
 }
 
-function wheelHandler({
-  table,
-  wrapper,
-  stickyElems,
-  pixelX,
-  pixelY,
-  scrollLeft,
-  scrollTop,
-  scrollWidth,
-  scrollHeight,
-  clientWidth,
-  clientHeight,
-  showShadow,
-  callback,
-}) {
-  const maxWidth = scrollWidth - clientWidth;
-  const maxHeight = scrollHeight - clientHeight;
-  let newX = scrollLeft + pixelX;
-  let newY = scrollTop + pixelY;
-  if (newX >= maxWidth) {
-    newX = maxWidth;
-  }
-  if (newX <= 0) {
-    newX = 0;
-  }
-  if (newY >= maxHeight) {
-    newY = maxHeight;
-  }
-  if (newY <= 0) {
-    newY = 0;
-  }
-
-  // Modern browsers have a nasty habit of setting scrollLeft/scrollTop not to the actual integer value you specified, but
-  // rather to a sub-pixel value that is "pretty close" to what you specified. To work around that, set the scroll value
-  // and then use the rendered scroll value as the left/top offset for the stuck elements.
-  wrapper.scrollTo(newX, newY);
-  // positionStickyElements(table, wrapper.scrollLeft, wrapper.scrollTop);
-
-  if (callback) {
-    callback(newX, newY);
-  }
-}
-
 function calculateShadowOffset(value) {
   value = Math.ceil(value / 10);
   if (value > 2) {
@@ -222,6 +179,9 @@ export default function (elems, options = {}) {
         const target = event.currentTarget;
         const normalized = normalizeWheel(event);
 
+        // Modern browsers have a nasty habit of setting scrollLeft/scrollTop not to the actual integer value you specified, but
+        // rather to a sub-pixel value that is "pretty close" to what you specified. This can cause the scrolled area to become out of sync with the "stuck" areas. To work around that, set the scroll value
+        // and then use the rendered scroll value as the left/top offset for the stuck elements.
         target.scrollTo(
           target.scrollLeft + normalized.pixelX,
           target.scrollTop + normalized.pixelY
@@ -235,6 +195,10 @@ export default function (elems, options = {}) {
             `${target.scrollLeft}px`
           );
           target.style.setProperty("--sns-scroll-top", `${target.scrollTop}px`);
+
+          if (callback) {
+            callback(target.scrollX, target.scrollY);
+          }
         });
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stick-n-slide",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "homepage": "http://brandalism.com/stick-n-slide",
   "description": "A javascript library that makes table cells stick to the x or y axis (or both) when the table is scrolled.",
   "keywords": [


### PR DESCRIPTION
Wrapping the CSS transform in a `requestAnimationFrame` after the code that scrolls the wrapper element seems to solve the issue. Not entirely, but that's more due to Safari's terrible scrolling performance than anything else at this point.